### PR TITLE
Scripted Abilities and Conditions can have custom data or properties changeable from JSON

### DIFF
--- a/common/src/main/java/net/threetag/palladium/compat/kubejs/ability/AbilityBuilder.java
+++ b/common/src/main/java/net/threetag/palladium/compat/kubejs/ability/AbilityBuilder.java
@@ -5,17 +5,39 @@ import dev.latvian.mods.kubejs.RegistryObjectBuilderTypes;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.Items;
+import net.threetag.palladium.Palladium;
 import net.threetag.palladium.compat.kubejs.AbilityEntryJS;
 import net.threetag.palladium.compat.kubejs.PalladiumKubeJSPlugin;
 import net.threetag.palladium.power.IPowerHolder;
 import net.threetag.palladium.power.ability.Ability;
 import net.threetag.palladium.util.icon.IIcon;
 import net.threetag.palladium.util.icon.ItemIcon;
+import net.threetag.palladium.util.property.PalladiumProperty;
+import net.threetag.palladium.util.property.PalladiumPropertyLookup;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class AbilityBuilder extends BuilderBase<Ability> {
 
+	class DeserializePropertyInfo {
+		String key;
+		String type;
+		Object defaultValue;
+		String configureDesc;
+
+		DeserializePropertyInfo(String key, String type, Object defaultValue, String configureDesc) {
+			this.key = key;
+			this.type = type;
+			this.defaultValue = defaultValue;
+			this.configureDesc = configureDesc;
+		}
+	}
+
     public transient IIcon icon;
     public transient TickFunction firstTick, tick, lastTick;
+
+	public transient List<DeserializePropertyInfo> propertyValues;
 
     public AbilityBuilder(ResourceLocation id) {
         super(id);
@@ -23,6 +45,7 @@ public class AbilityBuilder extends BuilderBase<Ability> {
         this.firstTick = null;
         this.tick = null;
         this.lastTick = null;
+		this.propertyValues = new ArrayList<>();
     }
 
     @Override
@@ -39,6 +62,17 @@ public class AbilityBuilder extends BuilderBase<Ability> {
         this.icon = icon;
         return this;
     }
+
+	public AbilityBuilder addProperty(String key, String type, Object defaultValue, String configureDesc) {
+		Palladium.LOGGER.info("AbilityBuilder#addProperty");
+		PalladiumProperty property = PalladiumPropertyLookup.get(type, key);
+
+		if (property != null)
+			this.propertyValues.add(new DeserializePropertyInfo(key, type, defaultValue, configureDesc));
+		else
+			Palladium.LOGGER.warn(String.format("Failed to register ability property \"%s\", type \"%s\" is not supported", key, type));
+		return this;
+	}
 
     public AbilityBuilder firstTick(TickFunction firstTick) {
         this.firstTick = firstTick;

--- a/common/src/main/java/net/threetag/palladium/compat/kubejs/ability/AbilityBuilder.java
+++ b/common/src/main/java/net/threetag/palladium/compat/kubejs/ability/AbilityBuilder.java
@@ -20,13 +20,13 @@ import java.util.List;
 
 public class AbilityBuilder extends BuilderBase<Ability> {
 
-	class DeserializePropertyInfo {
-		String key;
-		String type;
-		Object defaultValue;
-		String configureDesc;
+	public static class DeserializePropertyInfo {
+		public String key;
+		public String type;
+		public Object defaultValue;
+		public String configureDesc;
 
-		DeserializePropertyInfo(String key, String type, Object defaultValue, String configureDesc) {
+		public DeserializePropertyInfo(String key, String type, Object defaultValue, String configureDesc) {
 			this.key = key;
 			this.type = type;
 			this.defaultValue = defaultValue;
@@ -37,7 +37,7 @@ public class AbilityBuilder extends BuilderBase<Ability> {
     public transient IIcon icon;
     public transient TickFunction firstTick, tick, lastTick;
 
-	public transient List<DeserializePropertyInfo> propertyValues;
+	public transient List<DeserializePropertyInfo> extraProperties;
 
     public AbilityBuilder(ResourceLocation id) {
         super(id);
@@ -45,7 +45,7 @@ public class AbilityBuilder extends BuilderBase<Ability> {
         this.firstTick = null;
         this.tick = null;
         this.lastTick = null;
-		this.propertyValues = new ArrayList<>();
+		this.extraProperties = new ArrayList<>();
     }
 
     @Override
@@ -68,9 +68,9 @@ public class AbilityBuilder extends BuilderBase<Ability> {
 		PalladiumProperty property = PalladiumPropertyLookup.get(type, key);
 
 		if (property != null)
-			this.propertyValues.add(new DeserializePropertyInfo(key, type, defaultValue, configureDesc));
+			this.extraProperties.add(new DeserializePropertyInfo(key, type, defaultValue, configureDesc));
 		else
-			Palladium.LOGGER.warn(String.format("Failed to register ability property \"%s\", type \"%s\" is not supported", key, type));
+			Palladium.LOGGER.error(String.format("Failed to register ability property \"%s\", type \"%s\" is not supported", key, type));
 		return this;
 	}
 

--- a/common/src/main/java/net/threetag/palladium/compat/kubejs/ability/ScriptableAbility.java
+++ b/common/src/main/java/net/threetag/palladium/compat/kubejs/ability/ScriptableAbility.java
@@ -20,7 +20,7 @@ public class ScriptableAbility extends Ability {
 
 	    Palladium.LOGGER.info("ScriptableAbility constructor");
 
-		for (AbilityBuilder.DeserializePropertyInfo info : this.builder.propertyValues) {
+		for (AbilityBuilder.DeserializePropertyInfo info : this.builder.extraProperties) {
 			PalladiumProperty property = PalladiumPropertyLookup.get(info.type, info.key);
 
 			if (info.configureDesc != null && !info.configureDesc.isEmpty())

--- a/common/src/main/java/net/threetag/palladium/compat/kubejs/ability/ScriptableAbility.java
+++ b/common/src/main/java/net/threetag/palladium/compat/kubejs/ability/ScriptableAbility.java
@@ -1,10 +1,14 @@
 package net.threetag.palladium.compat.kubejs.ability;
 
 import net.minecraft.world.entity.LivingEntity;
+import net.threetag.palladium.Palladium;
 import net.threetag.palladium.compat.kubejs.AbilityEntryJS;
+import net.threetag.palladium.compat.kubejs.PalladiumKubeJSPlugin;
 import net.threetag.palladium.power.IPowerHolder;
 import net.threetag.palladium.power.ability.Ability;
 import net.threetag.palladium.power.ability.AbilityEntry;
+import net.threetag.palladium.util.property.PalladiumProperty;
+import net.threetag.palladium.util.property.PalladiumPropertyLookup;
 
 public class ScriptableAbility extends Ability {
 
@@ -13,6 +17,17 @@ public class ScriptableAbility extends Ability {
     public ScriptableAbility(AbilityBuilder builder) {
         this.withProperty(ICON, builder.icon);
         this.builder = builder;
+
+	    Palladium.LOGGER.info("ScriptableAbility constructor");
+
+		for (AbilityBuilder.DeserializePropertyInfo info : this.builder.propertyValues) {
+			PalladiumProperty property = PalladiumPropertyLookup.get(info.type, info.key);
+
+			if (info.configureDesc != null && !info.configureDesc.isEmpty())
+				property.configurable(info.configureDesc);
+
+			this.withProperty(property, PalladiumKubeJSPlugin.fixValues(property, info.defaultValue));
+		}
     }
 
     @Override

--- a/common/src/main/java/net/threetag/palladium/compat/kubejs/condition/ScriptableCondition.java
+++ b/common/src/main/java/net/threetag/palladium/compat/kubejs/condition/ScriptableCondition.java
@@ -1,6 +1,7 @@
 package net.threetag.palladium.compat.kubejs.condition;
 
 import net.minecraft.world.entity.LivingEntity;
+import net.threetag.palladium.Palladium;
 import net.threetag.palladium.condition.Condition;
 import net.threetag.palladium.condition.ConditionSerializer;
 import net.threetag.palladium.power.IPowerHolder;
@@ -8,19 +9,25 @@ import net.threetag.palladium.power.Power;
 import net.threetag.palladium.power.ability.AbilityEntry;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
+
 public class ScriptableCondition extends Condition {
 
     public final ConditionBuilder builder;
     public final ConditionSerializer serializer;
+	public final Map<String, Object> extraProperties;
 
-    public ScriptableCondition(ConditionBuilder builder, ConditionSerializer serializer) {
+    public ScriptableCondition(ConditionBuilder builder, ConditionSerializer serializer, Map<String, Object> extraProperties) {
         this.builder = builder;
         this.serializer = serializer;
+	    this.extraProperties = extraProperties;
+
+	    Palladium.LOGGER.info("ScriptableCondition constructor");
     }
 
     @Override
     public boolean active(LivingEntity entity, @Nullable AbilityEntry entry, @Nullable Power power, @Nullable IPowerHolder holder) {
-        return this.builder.test != null && this.builder.test.test(entity);
+        return this.builder.test != null && this.builder.test.test(entity, this.extraProperties);
     }
 
     @Override

--- a/run/addonpacks/Test Pack/addon/test/kubejs_scripts/custom_ability_and_condition.js
+++ b/run/addonpacks/Test Pack/addon/test/kubejs_scripts/custom_ability_and_condition.js
@@ -35,10 +35,11 @@ StartupEvents.registry('palladium:condition_serializer', (event) => {
 
   // ID of the condition will be: 'kubejs:testpack/test_condition'
   event.create('testpack/test_condition')
-
+    .addProperty("my_integer", "integer", 0, null)
     // Handler for the condition, in this case the condition will be fullfilled when the entity is crouching
-    .test((entity) => {
-      return entity.isCrouching();
+    .test((entity, extraProperties) => {
+        console.log(extraProperties.get("my_integer"))
+      return entity.isCrouching() && extraProperties.get("my_integer") == 4;
     });
 
 });

--- a/run/addonpacks/Test Pack/addon/test/kubejs_scripts/custom_ability_with_property.js
+++ b/run/addonpacks/Test Pack/addon/test/kubejs_scripts/custom_ability_with_property.js
@@ -1,0 +1,14 @@
+
+    StartupEvents.registry("palladium:abilities", event => {
+        event.create("testpack/test_ability_custom_prop")
+            .addProperty("selected_alien", "integer", 0, null)
+            .firstTick((entity, entry, holder, enabled) => {
+                console.log("old alien:" + entry.getProperty("selected_alien"))
+
+                let new_alien = entry.getProperty("selected_alien") + 1;
+                let result = entry.setProperty("selected_alien", new_alien)
+                console.log("set alien result:" + result)
+
+                console.log("new alien:" + entry.getProperty("selected_alien"))
+            })
+    })

--- a/run/addonpacks/Test Pack/addon/test/kubejs_scripts/custom_ability_with_property.js
+++ b/run/addonpacks/Test Pack/addon/test/kubejs_scripts/custom_ability_with_property.js
@@ -1,14 +1,14 @@
 
     StartupEvents.registry("palladium:abilities", event => {
         event.create("testpack/test_ability_custom_prop")
-            .addProperty("selected_alien", "integer", 0, null)
+            .addProperty("some_important_number", "integer", 0, null)
             .firstTick((entity, entry, holder, enabled) => {
-                console.log("old alien:" + entry.getProperty("selected_alien"))
+                // console.log prints out to the log text files
+                console.log("my custom property:" + entry.getProperty("some_important_number"))
 
-                let new_alien = entry.getProperty("selected_alien") + 1;
-                let result = entry.setProperty("selected_alien", new_alien)
-                console.log("set alien result:" + result)
-
-                console.log("new alien:" + entry.getProperty("selected_alien"))
+                // note that you cannot set property, as the property just added can never be changed.
+                let new_alien = entry.getProperty("some_important_number") + 1;
+                let result = entry.setProperty("some_important_number", new_alien)
+                console.log("setProperty result:" + result) // result always prints out as false, because the property CANNOT be changed
             })
     })

--- a/run/addonpacks/Test Pack/data/test/palladium/powers/custom_ability_property_test.json
+++ b/run/addonpacks/Test Pack/data/test/palladium/powers/custom_ability_property_test.json
@@ -1,0 +1,18 @@
+{
+	"name": "Custom Ability with Property Test",
+	"icon": "minecraft:diamond",
+	"abilities": {
+		"megumin": {
+			"type": "kubejs:testpack/test_ability_custom_prop",
+			"name": "Test Ability",
+			"selected_alien": 1,
+			"conditions": {
+				"enabling": [
+					{
+						"type": "palladium:action"
+					}
+				]
+			}
+		}
+	}
+}

--- a/run/addonpacks/Test Pack/data/test/palladium/powers/custom_ability_property_test.json
+++ b/run/addonpacks/Test Pack/data/test/palladium/powers/custom_ability_property_test.json
@@ -5,7 +5,7 @@
 		"megumin": {
 			"type": "kubejs:testpack/test_ability_custom_prop",
 			"name": "Test Ability",
-			"selected_alien": 1,
+			"some_important_number": 1,
 			"conditions": {
 				"enabling": [
 					{

--- a/run/addonpacks/Test Pack/data/test/palladium/powers/kube_js_test.json
+++ b/run/addonpacks/Test Pack/data/test/palladium/powers/kube_js_test.json
@@ -7,7 +7,8 @@
       "conditions": {
         "unlocking": [
           {
-            "type": "kubejs:testpack/test_condition"
+            "type": "kubejs:testpack/test_condition",
+		    "my_integer": 5
           }
         ],
         "enabling": [

--- a/run/mods/documentation/palladium/abilities.html
+++ b/run/mods/documentation/palladium/abilities.html
@@ -114,6 +114,10 @@ KubeJS</h3>
 <a href="#kubejs:testpack/test_ability">
 testpack/test_ability</a>
 </li>
+<li>
+<a href="#kubejs:testpack/test_ability_custom_prop">
+testpack/test_ability_custom_prop</a>
+</li>
 </ul>
 </p>
 <hr>
@@ -2851,6 +2855,132 @@ false</td>
 Example:</h3>
 <pre class="json-snippet">
 {"type":"kubejs:testpack/test_ability","icon":"palladium:vibranium_circuit","title":"null","bar_color":"light_gray","hidden":false,"list_index":-1,"gui_position":"null","description":"null"}</pre>
+</div>
+<hr>
+
+<div id="kubejs:testpack/test_ability_custom_prop">
+<h2>
+testpack/test_ability_custom_prop</h2>
+<h3>
+Settings:</h3>
+<table>
+<thead>
+<tr>
+<th>
+Setting</th>
+<th>
+Type</th>
+<th>
+Description</th>
+<th>
+Required</th>
+<th>
+Fallback Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+icon</td>
+<td>
+IIcon</td>
+<td>
+Icon for the ability</td>
+<td style="background-color: lightcoral">
+false</td>
+<td>
+ItemIcon{stack=1 barrier}</td>
+</tr>
+<tr>
+<td>
+title</td>
+<td>
+Component</td>
+<td>
+Allows you to set a custom title for this ability</td>
+<td style="background-color: lightcoral">
+false</td>
+<td>
+/</td>
+</tr>
+<tr>
+<td>
+bar_color</td>
+<td>
+AbilityColor</td>
+<td>
+Changes the color of the ability in the ability bar. Possible values: [white, orange, magenta, light_blue, yellow, lime, pink, gray, light_gray, cyan, purple, blue, brown, green, red, black]</td>
+<td style="background-color: lightcoral">
+false</td>
+<td>
+LIGHT_GRAY</td>
+</tr>
+<tr>
+<td>
+hidden</td>
+<td>
+Boolean</td>
+<td>
+Determines if the ability is visible in the ability bar and powers screen</td>
+<td style="background-color: lightcoral">
+false</td>
+<td>
+false</td>
+</tr>
+<tr>
+<td>
+list_index</td>
+<td>
+Integer</td>
+<td>
+Determines the list index for custom ability lists. Starts at 0. Going beyond 4 (which is the 5th place in the ability) will start a new list. Keeping it at -1 will automatically arrange the abilities.</td>
+<td style="background-color: lightcoral">
+false</td>
+<td>
+-1</td>
+</tr>
+<tr>
+<td>
+gui_position</td>
+<td>
+Vec2</td>
+<td>
+Position of the ability in the ability menu. Leave null for automatic positioning. 0/0 is center</td>
+<td style="background-color: lightcoral">
+false</td>
+<td>
+/</td>
+</tr>
+<tr>
+<td>
+description</td>
+<td>
+Component</td>
+<td>
+Description of the ability. Visible in ability menu</td>
+<td style="background-color: lightcoral">
+false</td>
+<td>
+/</td>
+</tr>
+<tr>
+<td>
+some_important_number</td>
+<td>
+Integer</td>
+<td>
+</td>
+<td style="background-color: lightcoral">
+false</td>
+<td>
+0</td>
+</tr>
+</tbody>
+</table>
+<h3>
+Example:</h3>
+<pre class="json-snippet">
+{"type":"kubejs:testpack/test_ability_custom_prop","icon":"minecraft:barrier","title":"null","bar_color":"light_gray","hidden":false,"list_index":-1,"gui_position":"null","description":"null","some_important_number":0}</pre>
 </div>
 <script>
 function syntaxHighlight(json) {

--- a/run/mods/documentation/palladium/conditions.html
+++ b/run/mods/documentation/palladium/conditions.html
@@ -1616,9 +1616,41 @@ testpack/test_condition</h2>
 <p>
 Applicable for: all</p>
 <h3>
+Settings:</h3>
+<table>
+<thead>
+<tr>
+<th>
+Setting</th>
+<th>
+Type</th>
+<th>
+Description</th>
+<th>
+Required</th>
+<th>
+Fallback Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+my_integer</td>
+<td>
+Integer</td>
+<td>
+</td>
+<td style="background-color: lightcoral">
+false</td>
+<td>
+0</td>
+</tr>
+</tbody>
+</table>
+<h3>
 Example:</h3>
 <pre class="json-snippet">
-{"type":"kubejs:testpack/test_condition"}</pre>
+{"type":"kubejs:testpack/test_condition","my_integer":0}</pre>
 </div>
 <script>
 function syntaxHighlight(json) {


### PR DESCRIPTION
As the title says, scripted abilities and conditions can have custom data attached to them, such that you can use those data in the ability's tick and condition's test functions respectively.

To see how their script code are written and how they can be used in JSON files, you can look at:
- Custom Ability with Property
  * [Script file](https://github.com/Spyeedy/Palladium/blob/1.19/run/addonpacks/Test%20Pack/addon/test/kubejs_scripts/custom_ability_with_property.js#L4)
  * [Superpower Json](https://github.com/Spyeedy/Palladium/blob/1.19/run/addonpacks/Test%20Pack/data/test/palladium/powers/custom_ability_property_test.json)
- Custom Condition with Property
  * [Script file](https://github.com/Spyeedy/Palladium/blob/1.19/run/addonpacks/Test%20Pack/addon/test/kubejs_scripts/custom_ability_and_condition.js#L38)
  * [Superpower Json](https://github.com/Spyeedy/Palladium/blob/1.19/run/addonpacks/Test%20Pack/data/test/palladium/powers/kube_js_test.json#L10-L11)

**Note**
By Palladium's design, the custom properties for scripted abilities **cannot** be modified during the lifetime of the ability, only retrieved, as mentioned in the ability script's comments.
Custom properties for scripted conditions also **cannot** be modified, only retrieved.