### PR TITLE
Use EXP Rate instead of flat level

### DIFF
--- a/common/src/main/java/net/threetag/palladium/condition/ExperienceLevelBuyableCondition.java
+++ b/common/src/main/java/net/threetag/palladium/condition/ExperienceLevelBuyableCondition.java
@@ -34,7 +34,7 @@ public class ExperienceLevelBuyableCondition extends BuyableCondition {
     @Override
     public boolean takeFromEntity(LivingEntity entity) {
         if (entity instanceof Player player && this.isAvailable(entity)) {
-            player.giveExperiencePoints(-getExpEquivalentForLevel(this.xpLevel));
+            player.giveExperiencePoints(-getTotalXpForLevel(this.xpLevel));
             return true;
         }
 
@@ -70,21 +70,14 @@ public class ExperienceLevelBuyableCondition extends BuyableCondition {
         }
     }
 
-    private int getExpEquivalentForLevel(int levelsToRemove) {
-        int xp = 0;
-        for (int level = 0; level < levels; level++) {
-            xp += getXpForLevel(level);
-        }
-        return xp;
-    }
-
-    private int getXpForLevel(int level) {
-        if (level >= 30) {
-            return 9 * level - 158;
-        } else if (level >= 15) {
-            return 5 * level - 38;
+    private int getTotalXpForLevel(int level) {
+        // https://minecraft.fandom.com/wiki/Experience#Leveling_up
+        if (level <= 16) {
+            return level * level + 6 * level;
+        } else if (level <= 31) {
+            return (int) (2.5 * level * level - 40.5 * level + 360);
         } else {
-            return 2 * level + 7;
+            return (int) (4.5 * level * level - 162.5 * level + 2220);
         }
     }
 }

--- a/common/src/main/java/net/threetag/palladium/condition/ExperienceLevelBuyableCondition.java
+++ b/common/src/main/java/net/threetag/palladium/condition/ExperienceLevelBuyableCondition.java
@@ -33,11 +33,9 @@ public class ExperienceLevelBuyableCondition extends BuyableCondition {
 
     @Override
     public boolean takeFromEntity(LivingEntity entity) {
-        if (entity instanceof Player player) {
-            if (player.experienceLevel >= this.xpLevel) {
-                player.giveExperienceLevels(-this.xpLevel);
-                return true;
-            }
+        if (entity instanceof Player player && this.isAvailable(entity)) {
+            player.giveExperiencePoints(-getExpEquivalentForLevel(this.xpLevel));
+            return true;
         }
 
         return false;
@@ -69,6 +67,24 @@ public class ExperienceLevelBuyableCondition extends BuyableCondition {
         @Override
         public String getDocumentationDescription() {
             return "A condition that makes the ability buyable for a certain amount of xp levels.";
+        }
+    }
+
+    private int getExpEquivalentForLevel(int levelsToRemove) {
+        int xp = 0;
+        for (int level = 0; level < levels; level++) {
+            xp += getXpForLevel(level);
+        }
+        return xp;
+    }
+
+    private int getXpForLevel(int level) {
+        if (level >= 30) {
+            return 9 * level - 158;
+        } else if (level >= 15) {
+            return 5 * level - 38;
+        } else {
+            return 2 * level + 7;
         }
     }
 }


### PR DESCRIPTION
Currently when we purchase something for X number of levels, you remove a flat X levels from the player.

However, for example, 5 levels at level 5 and 5 levels at level 105 is not the same amount of experience