### PR TITLE
Tool hands ability

### DIFF
--- a/common/src/main/java/net/threetag/palladium/mixin/PlayerMixin.java
+++ b/common/src/main/java/net/threetag/palladium/mixin/PlayerMixin.java
@@ -4,19 +4,25 @@ import com.mojang.authlib.GameProfile;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.ProfilePublicKey;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 import net.threetag.palladium.accessory.AccessoryPlayerData;
 import net.threetag.palladium.entity.FlightHandler;
 import net.threetag.palladium.entity.PalladiumPlayerExtension;
+import net.threetag.palladium.power.ability.Abilities;
+import net.threetag.palladium.power.ability.AbilityUtil;
+import net.threetag.palladium.power.ability.ToolHandsAbility;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @SuppressWarnings("DataFlowIssue")
 @Mixin(Player.class)
@@ -84,6 +90,14 @@ public abstract class PlayerMixin implements PalladiumPlayerExtension {
         CompoundTag palladiumTag = compound.contains("Palladium") ? compound.getCompound("Palladium") : new CompoundTag();
         palladiumTag.put("Accessories", this.palladium$accessories.toNBT());
         compound.put("Palladium", palladiumTag);
+    }
+
+
+    @Inject(method = "hasCorrectToolForDrops", at = @At("RETURN"), cancellable = true)
+    public void palladium$hasCorrectToolForDrops(BlockState state, CallbackInfoReturnable<Boolean> cir) {
+        if (!cir.getReturnValue()) AbilityUtil.getEnabledInstances((LivingEntity) (Object) this, Abilities.TOOL_HANDS.get()).forEach(abilityInstance -> {
+            if (ToolHandsAbility.blockDrops(abilityInstance, state)) cir.setReturnValue(true);
+        });
     }
 
     @Override

--- a/common/src/main/java/net/threetag/palladium/power/ability/Abilities.java
+++ b/common/src/main/java/net/threetag/palladium/power/ability/Abilities.java
@@ -50,6 +50,7 @@ public class Abilities {
     public static final RegistrySupplier<Ability> PARTICLES = ABILITIES.register("particles", ParticleAbility::new);
     public static final RegistrySupplier<Ability> IMMORTALITY = ABILITIES.register("immortality", ImmortalityAbility::new);
     public static final RegistrySupplier<Ability> ENTITY_GLOW = ABILITIES.register("entity_glow", EntityGlowAbility::new);
+    public static final RegistrySupplier<Ability> TOOL_HANDS = ABILITIES.register("tool_hands", ToolHandsAbility::new);
 
     public static void init() {
 

--- a/common/src/main/java/net/threetag/palladium/power/ability/ToolHandsAbility.java
+++ b/common/src/main/java/net/threetag/palladium/power/ability/ToolHandsAbility.java
@@ -1,0 +1,38 @@
+package net.threetag.palladium.power.ability;
+
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.DamageTypeTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.threetag.palladium.util.icon.ItemIcon;
+import net.threetag.palladium.util.property.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ToolHandsAbility extends Ability {
+
+    public static final PalladiumProperty<List<TagKey<Block>>> DROP_BLOCK_TAGS = new TagKeyListProperty<>("drop_block_tags", Registries.BLOCK).configurable("Blocks in these tags will be dropped when mined");
+
+    public ToolHandsAbility() {
+        this.withProperty(ICON, new ItemIcon(Items.WOODEN_PICKAXE));
+        this.withProperty(DROP_BLOCK_TAGS, Arrays.asList(BlockTags.MINEABLE_WITH_PICKAXE, BlockTags.NEEDS_IRON_TOOL));
+    }
+
+    public static boolean blockDrops(AbilityInstance instance, BlockState blockState) {
+        if (!instance.isEnabled()) return false;
+        for (TagKey<Block> blockTag : instance.getProperty(DROP_BLOCK_TAGS)) {
+            if (blockState.is(blockTag)) return true;
+        }
+        return false;
+    }
+
+    @Override
+    public String getDocumentationDescription() {
+        return "Allows the player to mine a block and receive its drops as if a tool were used";
+    }
+}

--- a/run/addonpacks/Test Pack/data/test/palladium/powers/tool_hands_test.json
+++ b/run/addonpacks/Test Pack/data/test/palladium/powers/tool_hands_test.json
@@ -1,0 +1,20 @@
+{
+  "name": "Tool Hands Test",
+  "icon": "wooden_pickaxe",
+  "abilities": {
+    "tool_hands": {
+      "type": "palladium:tool_hands",
+      "drop_block_tags": [
+        "minecraft:mineable/pickaxe",
+        "minecraft:needs_wooden_tool"
+      ]
+    },
+    "speed": {
+      "type": "palladium:attribute_modifier",
+      "attribute": "palladium:destroy_speed",
+      "amount": 3,
+      "operation": 0,
+      "uuid": "0a05b171-fb72-4638-4425-2964f90ac44b"
+    }
+  }
+}


### PR DESCRIPTION
An ability that makes blocks (that match any tag from a list of block tags) drop as if they were mined with the correct tool