### PR TITLE
Add type fixer for enum palladium property, new condition for openable item progress

### DIFF
--- a/common/src/main/java/net/threetag/palladium/condition/ConditionSerializers.java
+++ b/common/src/main/java/net/threetag/palladium/condition/ConditionSerializers.java
@@ -82,5 +82,6 @@ public class ConditionSerializers {
     public static final RegistrySupplier<ConditionSerializer> ACCESSORY_SELECTED = CONDITION_SERIALIZERS.register("accessory_selected", AccessorySelectedCondition.Serializer::new);
     public static final RegistrySupplier<ConditionSerializer> SMALL_ARMS = CONDITION_SERIALIZERS.register("small_arms", SmallArmsCondition.Serializer::new);
     public static final RegistrySupplier<ConditionSerializer> SIZE = CONDITION_SERIALIZERS.register("size", SizeCondition.Serializer::new);
+    public static final RegistrySupplier<ConditionSerializer> OPENABLE_ITEM_PROGRESS = CONDITION_SERIALIZERS.register("openable_item_progress", OpenableItemProgressCondition.Serializer::new);
 
 }

--- a/common/src/main/java/net/threetag/palladium/condition/OpenableItemProgressCondition.java
+++ b/common/src/main/java/net/threetag/palladium/condition/OpenableItemProgressCondition.java
@@ -1,0 +1,77 @@
+package net.threetag.palladium.condition;
+
+import com.google.gson.JsonObject;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.ItemStack;
+import net.threetag.palladium.item.Openable;
+import net.threetag.palladium.util.PlayerSlot;
+import net.threetag.palladium.util.context.DataContext;
+import net.threetag.palladium.util.property.IntegerProperty;
+import net.threetag.palladium.util.property.PalladiumProperty;
+import net.threetag.palladium.util.property.PlayerSlotProperty;
+
+public class OpenableItemProgressCondition extends Condition {
+
+    private final PlayerSlot slot;
+    private final int min;
+    private final int max;
+
+    public OpenableItemProgressCondition(PlayerSlot slot, int min, int max) {
+        this.slot = slot;
+        this.min = min;
+        this.max = max;
+    }
+
+    @Override
+    public boolean active(DataContext context) {
+        var entity = context.getLivingEntity();
+
+        if (entity == null) {
+            return false;
+        }
+
+        var stacks = this.slot.getItems(entity);
+
+        for (ItemStack stack : stacks) {
+            if (!stack.isEmpty() && stack.getItem() instanceof Openable openable) {
+                if (openable.isOpen(stack)) {
+                    int openProgress = openable.getOpeningProgress(stack);
+
+                    if (openProgress >= this.min && openProgress <= this.max) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public ConditionSerializer getSerializer() {
+        return ConditionSerializers.OPENABLE_ITEM_PROGRESS.get();
+    }
+
+    public static class Serializer extends ConditionSerializer {
+
+        public static final PalladiumProperty<PlayerSlot> SLOT = new PlayerSlotProperty("slot").configurable("Slot that must contain an opened item");
+        public static final PalladiumProperty<Integer> MIN = new IntegerProperty("min").configurable("Minimum required amount of the progress value");
+        public static final PalladiumProperty<Integer> MAX = new IntegerProperty("max").configurable("Maximum required amount of the progress value");
+
+        public Serializer() {
+            this.withProperty(SLOT, PlayerSlot.get(EquipmentSlot.CHEST.getName()));
+            this.withProperty(MIN, 0);
+            this.withProperty(MAX, 0);
+        }
+
+        @Override
+        public Condition make(JsonObject json) {
+            return new OpenableItemProgressCondition(this.getProperty(json, SLOT), this.getProperty(json, MIN), this.getProperty(json, MAX));
+        }
+
+        @Override
+        public String getDocumentationDescription() {
+            return "Checks if the openable item in the given slot has a certain amount of progress. Needs to be using the openable-system for items.";
+        }
+    }
+}

--- a/common/src/main/java/net/threetag/palladium/util/property/PalladiumProperty.java
+++ b/common/src/main/java/net/threetag/palladium/util/property/PalladiumProperty.java
@@ -114,6 +114,8 @@ public abstract class PalladiumProperty<T> {
             value = number.doubleValue();
         } else if (property instanceof ResourceLocationProperty && value instanceof String string) {
             value = new ResourceLocation(string);
+        } else if (property instanceof EnumPalladiumProperty<?> && value instanceof String string) {
+            value = ((EnumPalladiumProperty<?>) property).getByName(string);
         }
 
         return value;

--- a/run/mods/documentation/palladium/conditions.html
+++ b/run/mods/documentation/palladium/conditions.html
@@ -287,6 +287,10 @@ objective_score</a>
 on_ground</a>
 </li>
 <li>
+<a href="#palladium:openable_item_progress">
+openable_item_progress</a>
+</li>
+<li>
 <a href="#palladium:or">
 or</a>
 </li>
@@ -3027,6 +3031,74 @@ Checks if the entity is on the ground.<br><br>Applicable for: all</p>
 Example:</h3>
 <pre class="json-snippet">
 {"type":"palladium:on_ground"}</pre>
+</div>
+<hr>
+
+<div id="palladium:openable_item_progress">
+<h2>
+openable_item_progress</h2>
+<p>
+Checks if the openable item in the given slot has a certain amount of progress. Needs to be using the openable-system for items.<br><br>Applicable for: all</p>
+<h3>
+Settings:</h3>
+<table>
+<thead>
+<tr>
+<th>
+Setting</th>
+<th>
+Type</th>
+<th>
+Description</th>
+<th>
+Required</th>
+<th>
+Fallback Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+slot</td>
+<td>
+PlayerSlot</td>
+<td>
+Slot that must contain an opened item. Example values: [mainhand, offhand, feet, legs, chest, head, curios:back, curios:necklace, trinkets:chest/back, trinkets:chest/necklace]</td>
+<td style="background-color: lightcoral">
+false</td>
+<td>
+chest</td>
+</tr>
+<tr>
+<td>
+min</td>
+<td>
+Integer</td>
+<td>
+Minimum required amount of the progress value</td>
+<td style="background-color: lightcoral">
+false</td>
+<td>
+0</td>
+</tr>
+<tr>
+<td>
+max</td>
+<td>
+Integer</td>
+<td>
+Maximum required amount of the progress value</td>
+<td style="background-color: lightcoral">
+false</td>
+<td>
+0</td>
+</tr>
+</tbody>
+</table>
+<h3>
+Example:</h3>
+<pre class="json-snippet">
+{"type":"palladium:openable_item_progress","slot":"chest","min":0,"max":0}</pre>
 </div>
 <hr>
 


### PR DESCRIPTION
- Added missing palladium property fixer for EnumPalladiumProperty. It was causing a crash if one tried to add an equipment slot property via scripting
- Added a new condition, integer range check on an openable item's timer progress