### PR TITLE
Fixes behavior when an ability is held for only 1 tick

### DIFF
--- a/src/main/java/net/threetag/palladium/power/ability/enabling/KeyBindEnablingHandler.java
+++ b/src/main/java/net/threetag/palladium/power/ability/enabling/KeyBindEnablingHandler.java
@@ -215,7 +215,7 @@ public class KeyBindEnablingHandler extends EnablingHandler {
     }
 
     public void onKeyReleased(LivingEntity entity, AbilityInstance<?> abilityInstance) {
-        if (this.behaviour == Behaviour.HELD && abilityInstance.isEnabled()) {
+        if (this.behaviour == Behaviour.HELD) {
             if (entity.level().isClientSide()) {
                 ClientPacketDistributor.sendToServer(new AbilityKeyChangePacket(abilityInstance.getReference(), false));
             } else {


### PR DESCRIPTION
- Removes check that ability is enabled to release the key related to it. Currently, if you press and release a key in the same tick, the held ability is toggled on for the entire duration, instead of being toggled back off as soon as possible